### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cleanup.yaml
+++ b/.github/workflows/ci-cleanup.yaml
@@ -31,6 +31,8 @@ on:
 jobs:
   del_runs:
     name: Delete Undesirable Runs
+    permissions:
+      actions: write
     runs-on: ubuntu-latest
     steps:
       - name: Delete workflow runs


### PR DESCRIPTION
Potential fix for [https://github.com/BardezAnAvatar/RimWorld-Necro-Gene-Extractor/security/code-scanning/1](https://github.com/BardezAnAvatar/RimWorld-Necro-Gene-Extractor/security/code-scanning/1)

The best way to fix this security issue is to add an explicit `permissions` block within the workflow YAML file to restrict the permissions granted to the `GITHUB_TOKEN` to only the minimal set required for the jobs being run. In this specific workflow, the action `Mattraks/delete-workflow-runs@v2` must delete workflow runs, which requires `actions: write`, but no broader repository access. Therefore, you should add a `permissions:` key at the job level (`del_runs:`), just above `runs-on: ubuntu-latest`, setting `actions: write`. This change does not alter existing functionality: it only limits the token's scope strictly to what is required by the delete action.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

# Release Notes:
- Add permissions to Run deletion job
<sub>_End Release Notes_</sub>
