### PR TITLE
#29: Overdrive active at cycle start screwed up total time

### DIFF
--- a/src/NecroGeneExtractor/Buildings/NecroGeneExtractor_Base.cs
+++ b/src/NecroGeneExtractor/Buildings/NecroGeneExtractor_Base.cs
@@ -160,7 +160,7 @@ public abstract class NecroGeneExtractor_Base : GeneExtractorBase
             var hours = NecroSettings.CorpseFresh.CostTime * multiplier * TierSettings.CostMultiplierTime;
             if (OverchargeActive)
             {
-                hours *= TierSettings.CostMultiplierOverdriveTime;
+                hours /= TierSettings.CostMultiplierOverdriveTime;
             }
 
             return Convert.ToInt32(hours) * TICKS_PER_HOUR;


### PR DESCRIPTION
# Release Notes:
- Fixes #29 (Subsequent cycles taking too long?)
<sub>_End Release Notes_</sub>