### PR TITLE
#30: Exception raised upon targeting genes when no unextracted genes remain

### DIFF
--- a/src/GeneExtractorTiers/Gui/FloatMenuHelper.cs
+++ b/src/GeneExtractorTiers/Gui/FloatMenuHelper.cs
@@ -20,13 +20,11 @@ public static class FloatMenuHelper
         }
 
         var existingGenes = GeneHelper.GetAllGenesOnMap(map);
-        foreach (var gene in allPawnGenes)
-        {
-            if (existingGenes.ContainsKey(gene) && existingGenes[gene] == GeneState.SinglePack)
-            {
-                continue;
-            }
+        var missingGenes = allPawnGenes
+            .Where(gene => !existingGenes.ContainsKey(gene) || existingGenes[gene] != GeneState.SinglePack);
 
+        foreach (var gene in missingGenes.Any() ? missingGenes : allPawnGenes)
+        {
             list.Add(new FloatMenuOption(gene.LabelCap, delegate
             {
                 setTargetGene(gene);


### PR DESCRIPTION
Resolves #30

# Release Notes:
- Allow targeting of any genes if all genes are already extracted in single genepacks
- Optimization: Fewer unnecessary calls to `GeneHelper.GetAllGenesOnMap`
<sub>_End Release Notes_</sub>